### PR TITLE
Add material design framework and fix integration bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3968,6 +3968,11 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
+    },
     "handle-thing": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
     "@angular/router": "^4.2.4",
     "@types/marked": "^0.3.0",
     "core-js": "^2.4.1",
+    "hammerjs": "^2.0.8",
     "highlight.js": "^9.12.0",
     "highlightjs": "^9.10.0",
     "marked": "^0.3.6",
     "ng2-ace-editor": "^0.3.1",
-    "rxjs": "^5.4.2",
+    "rxjs": "^5.4.3",
     "zone.js": "^0.8.14"
   },
   "devDependencies": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
+import { Http } from '@angular/http';
+import 'rxjs/Rx';
 
 @Component({
   selector: 'app-root',
@@ -13,4 +15,11 @@ export class AppComponent {
   onEditorInput(event) {
     this.content = event;
   }
+//  myData: Array<any>;
+
+  // constructor(private http: Http) {
+  //   this.http.get('https://jsonplaceholder.typicode.com/photos')
+  //   .map(response => response.json())
+  //   .subscribe(res => this.myData = res);
+  // }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,12 +2,49 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms'; // <-- NgModel lives here
 import { AceEditorModule } from 'ng2-ace-editor';
-
 import { AppComponent } from './app.component';
 import { ToolbarComponent } from './toolbar/toolbar.component';
 import { EditorComponent } from './editor/editor.component';
 import { PreviewComponent } from './preview/preview.component';
-import {MatButtonModule, MatCheckboxModule} from '@angular/material';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { HttpModule } from '@angular/http';
+import { CdkTableModule } from '@angular/cdk/table';
+
+import {
+  MatAutocompleteModule,
+  MatButtonModule,
+  MatButtonToggleModule,
+  MatCardModule,
+  MatCheckboxModule,
+  MatChipsModule,
+  MatDatepickerModule,
+  MatDialogModule,
+  MatExpansionModule,
+  MatGridListModule,
+  MatIconModule,
+  MatInputModule,
+  MatListModule,
+  MatMenuModule,
+  MatNativeDateModule,
+  MatPaginatorModule,
+  MatProgressBarModule,
+  MatProgressSpinnerModule,
+  MatRadioModule,
+  MatRippleModule,
+  MatSelectModule,
+  MatSidenavModule,
+  MatSliderModule,
+  MatSlideToggleModule,
+  MatSnackBarModule,
+  MatSortModule,
+  MatTableModule,
+  MatTabsModule,
+  MatToolbarModule,
+  MatTooltipModule,
+  MatStepperModule,
+} from '@angular/material';
+
 
 @NgModule({
   declarations: [
@@ -21,11 +58,12 @@ import {MatButtonModule, MatCheckboxModule} from '@angular/material';
     FormsModule,
     AceEditorModule,
     MatButtonModule,
-    MatCheckboxModule
+    MatCheckboxModule,
+    BrowserAnimationsModule,
   ],
   exports: [
     MatButtonModule,
-    MatCheckboxModule
+    MatCheckboxModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/index.html
+++ b/src/index.html
@@ -3,16 +3,17 @@
 <html lang="en">
 
 <head>
-    <base href="/">
+  <base href="/">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="">
   <meta name="author" content="">
 
-  <title>Markit.</title>
+  <title>Live Markdown Editor</title>
 
   <!-- Bootstrap core CSS -->
-  <!-- <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet"> -->
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M"
     crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,9 +4,13 @@
  * Licensed under MIT (https://github.com/BlackrockDigital/startbootstrap-blog-home/blob/master/LICENSE)
  */
 
+/* @import '~@angular/material/prebuilt-themes/indigo-pink.css'; */
+
 body {
+    /* padding: 2em 23em; */
     padding-top: 124px;
     margin-bottom: 30px;
+    background: lightgray;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
# Adapted the usage of https://material.angular.io/ to our App.

This new framework is intended to provide a consistent design for web development. Material Design is Google's cohesive design language, featured in prominent places such as the latest versions of Android as well as Youtube and Gmail.

### This commit only adds the framework on top of what we have, but it does not yet actually change any of our design at this point.