### PR TITLE
Add Popup component and dialog, fix numerous integration bugs.

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,7 +15,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <app-fucku></app-fucku>
+      <app-popup-trigger></app-popup-trigger>
     </div>
   </div>
   <!-- /.row -->

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,9 +9,12 @@
       <app-preview [data]="content"></app-preview>
     </div>
   </div>
-  <!-- /.row -->
 </div>
-<br><br><br><br><br>
+<br>
+<br>
+<br>
+<br>
+<br>
 <div class="container">
   <div class="row">
     <div class="col-md-12">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,18 +3,27 @@
 <div class="container">
   <div class="row">
     <div class="col-md-6">
-     <app-editor [userInput]="content" (notifyEditorTextChanged)="onEditorInput($event)"></app-editor>
+      <app-editor [userInput]="content" (notifyEditorTextChanged)="onEditorInput($event)"></app-editor>
     </div>
     <div class="col-md-6">
-        <app-preview [data]="content" ></app-preview>
+      <app-preview [data]="content"></app-preview>
     </div>
   </div>
   <!-- /.row -->
-  </div>
-  <!-- /.container -->
-  <!-- Footer -->
-  <footer class="py-5 bg-dark footer">
-    <div class="container">
-      <p class="m-0 text-center text-white">Copyright &copy; BSU SDD Fall 2017</p>
+</div>
+<br><br><br><br><br>
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <app-fucku></app-fucku>
     </div>
-  </footer>
+  </div>
+  <!-- /.row -->
+</div>
+<!-- /.container -->
+<!-- Footer -->
+<footer class="py-5 bg-dark footer">
+  <div class="container">
+    <p class="m-0 text-center text-white">Copyright &copy; BSU SDD Fall 2017</p>
+  </div>
+</footer>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-6">
-      <app-editor [userInput]="content" (notifyEditorTextChanged)="onEditorInput($event)"></app-editor>
+      <app-editor (notifyEditorTextChanged)="onEditorInput($event)"></app-editor>
     </div>
     <div class="col-md-6">
       <app-preview [data]="content"></app-preview>
@@ -15,7 +15,6 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <app-popup-trigger></app-popup-trigger>
     </div>
   </div>
   <!-- /.row -->

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,16 +10,9 @@ import 'rxjs/Rx';
 
 export class AppComponent {
   content: string;
-  title= 'Markit.';
+  title = 'Markit.';
 
   onEditorInput(event) {
     this.content = event;
   }
-//  myData: Array<any>;
-
-  // constructor(private http: Http) {
-  //   this.http.get('https://jsonplaceholder.typicode.com/photos')
-  //   .map(response => response.json())
-  //   .subscribe(res => this.myData = res);
-  // }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,7 +8,7 @@ import { EditorComponent } from './editor/editor.component';
 import { PreviewComponent } from './preview/preview.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { DialogOverviewButtComponent, PopupComponent  } from './popup/popup.component';
+import { DialogOverviewButtonComponent, PopupComponent  } from './popup/popup.component';
 import { HttpModule } from '@angular/http';
 import { CdkTableModule } from '@angular/cdk/table';
 
@@ -54,7 +54,7 @@ import {
     ToolbarComponent,
     EditorComponent,
     PreviewComponent,
-    DialogOverviewButtComponent,
+    DialogOverviewButtonComponent,
     PopupComponent
   ],
   imports: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,17 +1,20 @@
+/* Angular specific imports */
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms'; // <-- NgModel lives here
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { HttpModule } from '@angular/http';
+import { CdkTableModule } from '@angular/cdk/table';
+/* external imports */
 import { AceEditorModule } from 'ng2-ace-editor';
+/* SDD_SMALLPROJECT components */
+import { DialogOverviewButtonComponent, PopupComponent } from './popup/popup.component';
 import { AppComponent } from './app.component';
 import { ToolbarComponent } from './toolbar/toolbar.component';
 import { EditorComponent } from './editor/editor.component';
 import { PreviewComponent } from './preview/preview.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { DialogOverviewButtonComponent, PopupComponent  } from './popup/popup.component';
-import { HttpModule } from '@angular/http';
-import { CdkTableModule } from '@angular/cdk/table';
-
+/* Angular Material design imports, see: https://material.angular.io */
 import {
   MatAutocompleteModule,
   MatButtonModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,7 +8,7 @@ import { EditorComponent } from './editor/editor.component';
 import { PreviewComponent } from './preview/preview.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { PopupComponent } from './popup/popup.component';
+import { DialogOverviewButtComponent, PopupComponent  } from './popup/popup.component';
 import { HttpModule } from '@angular/http';
 import { CdkTableModule } from '@angular/cdk/table';
 
@@ -54,7 +54,8 @@ import {
     ToolbarComponent,
     EditorComponent,
     PreviewComponent,
-    PopupComponent,
+    DialogOverviewButtComponent,
+    PopupComponent
   ],
   imports: [
     BrowserModule,
@@ -62,6 +63,7 @@ import {
     AceEditorModule,
     MatButtonModule,
     MatCheckboxModule,
+    MatDialogModule,
     BrowserAnimationsModule,
   ],
   exports: [
@@ -69,6 +71,7 @@ import {
     MatCheckboxModule,
   ],
   providers: [],
+  entryComponents: [PopupComponent],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/popup/popup.component.button.html
+++ b/src/app/popup/popup.component.button.html
@@ -1,0 +1,3 @@
+<ol>
+    <button mat-raised-button (click)="openDialog()">Pick one</button>
+</ol>

--- a/src/app/popup/popup.component.button.html
+++ b/src/app/popup/popup.component.button.html
@@ -1,3 +1,3 @@
 <ol>
-    <button mat-raised-button (click)="openDialog()">Pick one</button>
+    <button mat-raised-button (click)="openDialog()">View parsed HTML</button>
 </ol>

--- a/src/app/popup/popup.component.dialog.html
+++ b/src/app/popup/popup.component.dialog.html
@@ -1,0 +1,7 @@
+<h1 mat-dialog-title>Hi </h1>
+<div mat-dialog-content>
+  <p>Hello :)</p>
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="onNoClick()" tabindex="-1">No Thanks</button>
+</div>

--- a/src/app/popup/popup.component.dialog.html
+++ b/src/app/popup/popup.component.dialog.html
@@ -1,7 +1,0 @@
-<h1 mat-dialog-title>Hi </h1>
-<div mat-dialog-content>
-  <p>Hello :)</p>
-</div>
-<div mat-dialog-actions>
-  <button mat-button (click)="onNoClick()" tabindex="-1">No Thanks</button>
-</div>

--- a/src/app/popup/popup.component.html
+++ b/src/app/popup/popup.component.html
@@ -1,3 +1,6 @@
-<ol>
-    <button mat-raised-button (click)="openDialog()">Pick one</button>
-</ol>
+<div mat-dialog-content>
+  <p>{{data.convertedHTML}}</p>
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="onNoClick()" tabindex="-1">No Thanks</button>
+</div>

--- a/src/app/popup/popup.component.html
+++ b/src/app/popup/popup.component.html
@@ -2,5 +2,5 @@
   <p>{{data.convertedHTML}}</p>
 </div>
 <div mat-dialog-actions>
-  <button mat-button (click)="onNoClick()" tabindex="-1">No Thanks</button>
+  <button mat-button (click)="onNoClick()" tabindex="-1">Close</button>
 </div>

--- a/src/app/popup/popup.component.html
+++ b/src/app/popup/popup.component.html
@@ -1,3 +1,3 @@
-<p>
-  popup works!
-</p>
+<ol>
+    <button mat-raised-button (click)="openDialog()">Pick one</button>
+</ol>

--- a/src/app/popup/popup.component.spec.ts
+++ b/src/app/popup/popup.component.spec.ts
@@ -1,4 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, OnInit, Inject } from '@angular/core';
+import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
 
 import { PopupComponent } from './popup.component';
 
@@ -22,4 +24,6 @@ describe('PopupComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  
 });

--- a/src/app/popup/popup.component.ts
+++ b/src/app/popup/popup.component.ts
@@ -5,10 +5,10 @@ import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
  * @title Dialog Overview
  */
 @Component({
-  selector: 'app-fucku',
+  selector: 'app-popup-trigger',
   templateUrl: 'popup.component.html'
 })
-export class DialogOverviewButtComponent {
+export class DialogOverviewButtonComponent {
   constructor(public dialog: MatDialog) {}
 
   openDialog(): void {

--- a/src/app/popup/popup.component.ts
+++ b/src/app/popup/popup.component.ts
@@ -9,14 +9,13 @@ import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
   providers: []
 })
 export class PopupComponent {
-  someValue = false;
 
   constructor(
     public dialogRef: MatDialogRef<PopupComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any) { }
 
   onNoClick(): void {
-    this.dialogRef.close(this.someValue);
+    this.dialogRef.close();
   }
 
 }

--- a/src/app/popup/popup.component.ts
+++ b/src/app/popup/popup.component.ts
@@ -1,15 +1,43 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
+import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
+
+/**
+ * @title Dialog Overview
+ */
+@Component({
+  selector: 'app-fucku',
+  templateUrl: 'popup.component.html'
+})
+export class DialogOverviewButtComponent {
+  constructor(public dialog: MatDialog) {}
+
+  openDialog(): void {
+    let dialogRef = this.dialog.open(PopupComponent, {
+      width: '250px'
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      console.log('The dialog was closed');
+    });
+  }
+
+}
 
 @Component({
   selector: 'app-popup',
-  templateUrl: './popup.component.html',
-  styleUrls: ['./popup.component.css']
+  templateUrl: './popup.component.dialog.html',
+  styleUrls: ['./popup.component.css'],
+  providers: []
 })
-export class PopupComponent implements OnInit {
+export class PopupComponent {
+  someValue = false;
 
-  constructor() { }
+  constructor(
+    public dialogRef: MatDialogRef<PopupComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any) { }
 
-  ngOnInit() {
+  onNoClick(): void {
+    this.dialogRef.close(this.someValue);
   }
 
 }

--- a/src/app/popup/popup.component.ts
+++ b/src/app/popup/popup.component.ts
@@ -1,31 +1,10 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit, Inject, OnChanges, Input } from '@angular/core';
 import {MatDialog, MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
 
-/**
- * @title Dialog Overview
- */
-@Component({
-  selector: 'app-popup-trigger',
-  templateUrl: 'popup.component.html'
-})
-export class DialogOverviewButtonComponent {
-  constructor(public dialog: MatDialog) {}
-
-  openDialog(): void {
-    let dialogRef = this.dialog.open(PopupComponent, {
-      width: '250px'
-    });
-
-    dialogRef.afterClosed().subscribe(result => {
-      console.log('The dialog was closed');
-    });
-  }
-
-}
 
 @Component({
   selector: 'app-popup',
-  templateUrl: './popup.component.dialog.html',
+  templateUrl: './popup.component.html',
   styleUrls: ['./popup.component.css'],
   providers: []
 })
@@ -38,6 +17,29 @@ export class PopupComponent {
 
   onNoClick(): void {
     this.dialogRef.close(this.someValue);
+  }
+
+}
+
+@Component({
+  selector: 'app-button',
+  templateUrl: './popup.component.button.html'
+})
+
+export class DialogOverviewButtonComponent {
+  @Input('convertedHTML')
+  convertedHTML = '';
+  constructor(public dialog: MatDialog) {}
+
+  openDialog(): void {
+    let dialogRef = this.dialog.open(PopupComponent, {
+      data: { convertedHTML: this.convertedHTML },
+      width: '250px'
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      console.log('The dialog was closed');
+    });
   }
 
 }

--- a/src/app/preview/preview.component.ts
+++ b/src/app/preview/preview.component.ts
@@ -5,9 +5,10 @@ import {MarkdownService} from '../services/markdown-service.service';
 
 @Component({
   selector: 'app-preview',
-  template: `<h2>Preview</h2>
-  <div [innerHTML]="convertedData">
-  </div>`,
+  template:
+  `<h2>Preview</h2>
+  <app-button [convertedHTML] = "convertedData"></app-button>
+  <div [innerHTML]="convertedData"></div>`,
   providers: [MarkdownService]
 })
 
@@ -22,5 +23,6 @@ export class PreviewComponent implements OnChanges {
     ngOnChanges() {
       console.log(this.data);
       this.convertedData = this.markdown.convert(this.data);
+      console.log(this.convertedData);
     }
   }


### PR DESCRIPTION
# Material design popup

With this version, we now have a Popup from Angular's Material Design framework. The reference can be found [in Google's Material Design documentation.](https://material.angular.io/components/dialog/overview)

Please note that there are two new Components, found in popup.component.html, and also in popup.component.dialog.html. The dialog is the popup and the other is the trigger for the popup. The trigger must be associated with the popup.

The animations and styling are already quite good, but the formatting is unfortunate at this time. This is cause for future cards.